### PR TITLE
fix(api): Improve error handling for invalid domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_VERSION = 1.53.3
+GOLANGCI_VERSION = 1.59.1
 LICENCES_IGNORE_LIST = $(shell cat licenses/licenses-ignore-list.txt)
 
 VERSION ?= 0.0.1


### PR DESCRIPTION
Updating or deleting DNS records fails if some service is configured with an invalid domain name.

To reproduce the problem, assume that a user has created a domain `test1234.runs.on.stackit.cloud`, and has set up two loadbalancer services in the cluster. Service A is configured to use domain `service.test1234.runs.on.stackit.cloud`, and Service B uses domain `service.test1234-invalid.runs.on.stackit.cloud` (notice the `-invalid`). Wait until the DNS records of service A are created by external DNS in the test1234 domain. Then remove Service A. Notice that the DNS record is not removed as long as Service B with the invalid domain exists.

This is a result of the error handling in `StackitDNSProvider.ApplyChanges` which exits on the first error. As a result an invalid domain will block all Update / Delete operations. To address the problem, I've changed the code to collect all changeTasks first and execute all of them at once. This design is also used by some in-tree extension of external-dns and ensures that an invalid domain cannot block other operations.