### PR TITLE
feat: Set an explicit BodyLimit to reduce risk of running into status 413 for large external-dns payloads

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,6 +73,7 @@ func New(logger *zap.Logger, middlewareCollector metrics.HttpApiMetrics, provide
 		DisableStartupMessage: true,
 		JSONEncoder:           json.Marshal,
 		JSONDecoder:           json.Unmarshal,
+		BodyLimit:             12 * 1024 * 1024,
 	})
 
 	registerAt(app, "/metrics")


### PR DESCRIPTION
Fix for https://github.com/stackitcloud/external-dns-stackit-webhook/issues/30