### PR TITLE
chore: Update release pipeline to use GoReleaser v6 and simplify steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,23 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Git Fetch
-        run: git fetch --force --tags
-
       - name: Setup go
         uses: actions/setup-go@v6
         with:
           go-version: stable
 
-      - name: Cache Go Modules
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - uses: anchore/sbom-action/download-syft@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
 
       - name: Set Up Docker Buildx
@@ -53,7 +41,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release with Goreleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by removing unnecessary steps and upgrading the GoReleaser action version. These changes help streamline the workflow and ensure compatibility with the latest tooling.

Workflow cleanup and modernization:

* Removed the explicit `git fetch --force --tags` step, as it is no longer necessary for the release process.
* Removed the Go modules caching step, simplifying the workflow and potentially reducing issues with stale dependencies.

Dependency/tooling updates:

* Upgraded the `goreleaser/goreleaser-action` from version `v4` to `v6` to use the latest features and fixes.…ry steps