### PR TITLE
fix: split long TXT records into 255-character chunks

### DIFF
--- a/internal/stackitprovider/helper.go
+++ b/internal/stackitprovider/helper.go
@@ -71,8 +71,14 @@ func modifyChange(change *endpoint.Endpoint) {
 func getStackitRecordSetPayload(change *endpoint.Endpoint) stackitdnsclient.CreateRecordSetPayload {
 	records := make([]stackitdnsclient.RecordPayload, len(change.Targets))
 	for i := range change.Targets {
+		content := change.Targets[i]
+
+		if change.RecordType == "TXT" {
+			content = formatTXTContent(content)
+		}
+
 		records[i] = stackitdnsclient.RecordPayload{
-			Content: change.Targets[i],
+			Content: content,
 		}
 	}
 
@@ -88,8 +94,14 @@ func getStackitRecordSetPayload(change *endpoint.Endpoint) stackitdnsclient.Crea
 func getStackitPartialUpdateRecordSetPayload(change *endpoint.Endpoint) stackitdnsclient.PartialUpdateRecordSetPayload {
 	records := make([]stackitdnsclient.RecordPayload, len(change.Targets))
 	for i := range change.Targets {
+		content := change.Targets[i]
+
+		if change.RecordType == "TXT" {
+			content = formatTXTContent(content)
+		}
+
 		records[i] = stackitdnsclient.RecordPayload{
-			Content: change.Targets[i],
+			Content: content,
 		}
 	}
 
@@ -125,4 +137,34 @@ func safeTTLToInt32(ttl endpoint.TTL) *int32 {
 	}
 
 	return &v
+}
+
+// formatTXTContent splits long TXT records into 255-character chunks separated by spaces
+func formatTXTContent(content string) string {
+	cleanContent := strings.Trim(content, "\"")
+
+	if len(cleanContent) <= 255 {
+		return `"` + cleanContent + `"`
+	}
+
+	var chunks []string
+	for i := 0; i < len(cleanContent); i += 255 {
+		end := i + 255
+		if end > len(cleanContent) {
+			end = len(cleanContent)
+		}
+		chunks = append(chunks, `"`+cleanContent[i:end]+`"`)
+	}
+
+	return strings.Join(chunks, " ")
+}
+
+// unformatTXTContent reverses the DNS chunking and quoting process
+func unformatTXTContent(content string) string {
+	if !strings.HasPrefix(content, "\"") || !strings.HasSuffix(content, "\"") {
+		return content
+	}
+
+	trimmed := content[1 : len(content)-1]
+	return strings.ReplaceAll(trimmed, `" "`, "")
 }

--- a/internal/stackitprovider/helper.go
+++ b/internal/stackitprovider/helper.go
@@ -73,7 +73,7 @@ func getStackitRecordSetPayload(change *endpoint.Endpoint) stackitdnsclient.Crea
 	for i := range change.Targets {
 		content := change.Targets[i]
 
-		if change.RecordType == "TXT" {
+		if change.RecordType == txtRecord {
 			content = formatTXTContent(content)
 		}
 
@@ -96,7 +96,7 @@ func getStackitPartialUpdateRecordSetPayload(change *endpoint.Endpoint) stackitd
 	for i := range change.Targets {
 		content := change.Targets[i]
 
-		if change.RecordType == "TXT" {
+		if change.RecordType == txtRecord {
 			content = formatTXTContent(content)
 		}
 
@@ -139,7 +139,7 @@ func safeTTLToInt32(ttl endpoint.TTL) *int32 {
 	return &v
 }
 
-// formatTXTContent splits long TXT records into 255-character chunks separated by spaces
+// formatTXTContent splits long TXT records into 255-character chunks separated by spaces.
 func formatTXTContent(content string) string {
 	cleanContent := strings.Trim(content, "\"")
 
@@ -159,12 +159,13 @@ func formatTXTContent(content string) string {
 	return strings.Join(chunks, " ")
 }
 
-// unformatTXTContent reverses the DNS chunking and quoting process
+// unformatTXTContent reverses the DNS chunking and quoting process.
 func unformatTXTContent(content string) string {
 	if !strings.HasPrefix(content, "\"") || !strings.HasSuffix(content, "\"") {
 		return content
 	}
 
 	trimmed := content[1 : len(content)-1]
+
 	return strings.ReplaceAll(trimmed, `" "`, "")
 }

--- a/internal/stackitprovider/helper.go
+++ b/internal/stackitprovider/helper.go
@@ -141,10 +141,10 @@ func safeTTLToInt32(ttl endpoint.TTL) *int32 {
 
 // formatTXTContent splits long TXT records into 255-character chunks separated by spaces.
 func formatTXTContent(content string) string {
-	cleanContent := strings.Trim(content, "\"")
+	cleanContent := strings.Trim(content, `"`)
 
 	if len(cleanContent) <= 255 {
-		return `"` + cleanContent + `"`
+		return content
 	}
 
 	var chunks []string
@@ -161,11 +161,9 @@ func formatTXTContent(content string) string {
 
 // unformatTXTContent reverses the DNS chunking and quoting process.
 func unformatTXTContent(content string) string {
-	if !strings.HasPrefix(content, "\"") || !strings.HasSuffix(content, "\"") {
-		return content
+	if strings.Contains(content, `" "`) {
+		return strings.ReplaceAll(content, `" "`, ``)
 	}
 
-	trimmed := content[1 : len(content)-1]
-
-	return strings.ReplaceAll(trimmed, `" "`, "")
+	return content
 }

--- a/internal/stackitprovider/helper_test.go
+++ b/internal/stackitprovider/helper_test.go
@@ -2,6 +2,7 @@ package stackitprovider
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	stackitdnsclient "github.com/stackitcloud/stackit-sdk-go/services/dns/v1api"
@@ -212,5 +213,97 @@ func TestGetStackitRRSetRecordPatch(t *testing.T) {
 
 	if !reflect.DeepEqual(got, expected) {
 		t.Errorf("getStackitRRSetRecordPatch() = %v, want %v", got, expected)
+	}
+}
+
+func TestFormatTXTContent(t *testing.T) {
+	t.Parallel()
+
+	// Generate strings of exact lengths for testing
+	string255 := strings.Repeat("a", 255)
+	string256 := strings.Repeat("a", 256)
+	string511 := strings.Repeat("a", 511)
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "Short string without quotes",
+			content: "hello world",
+			want:    `"hello world"`,
+		},
+		{
+			name:    "Short string with existing quotes",
+			content: `"hello world"`,
+			want:    `"hello world"`,
+		},
+		{
+			name:    "Exactly 255 characters",
+			content: string255,
+			want:    `"` + string255 + `"`,
+		},
+		{
+			name:    "256 characters (requires 2 chunks)",
+			content: string256,
+			want:    `"` + string255 + `" "a"`,
+		},
+		{
+			name:    "511 characters (requires 3 chunks)",
+			content: string511,
+			want:    `"` + string255 + `" "` + string255 + `" "a"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := formatTXTContent(tt.content); got != tt.want {
+				t.Errorf("formatTXTContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnformatTXTContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "Unquoted short string",
+			content: "hello world",
+			want:    "hello world",
+		},
+		{
+			name:    "Single chunk quoted string",
+			content: `"hello world"`,
+			want:    "hello world",
+		},
+		{
+			name:    "Two chunk string",
+			content: `"hello" "world"`,
+			want:    "helloworld",
+		},
+		{
+			name:    "Three chunk string",
+			content: `"chunk1" "chunk2" "chunk3"`,
+			want:    "chunk1chunk2chunk3",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := unformatTXTContent(tt.content); got != tt.want {
+				t.Errorf("unformatTXTContent() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/stackitprovider/helper_test.go
+++ b/internal/stackitprovider/helper_test.go
@@ -232,7 +232,7 @@ func TestFormatTXTContent(t *testing.T) {
 		{
 			name:    "Short string without quotes",
 			content: "hello world",
-			want:    `"hello world"`,
+			want:    "hello world",
 		},
 		{
 			name:    "Short string with existing quotes",
@@ -240,8 +240,13 @@ func TestFormatTXTContent(t *testing.T) {
 			want:    `"hello world"`,
 		},
 		{
-			name:    "Exactly 255 characters",
+			name:    "Exactly 255 characters unquoted",
 			content: string255,
+			want:    string255,
+		},
+		{
+			name:    "Exactly 255 characters quoted",
+			content: `"` + string255 + `"`,
 			want:    `"` + string255 + `"`,
 		},
 		{
@@ -283,17 +288,17 @@ func TestUnformatTXTContent(t *testing.T) {
 		{
 			name:    "Single chunk quoted string",
 			content: `"hello world"`,
-			want:    "hello world",
+			want:    `"hello world"`,
 		},
 		{
 			name:    "Two chunk string",
 			content: `"hello" "world"`,
-			want:    "helloworld",
+			want:    `"helloworld"`,
 		},
 		{
 			name:    "Three chunk string",
 			content: `"chunk1" "chunk2" "chunk3"`,
-			want:    "chunk1chunk2chunk3",
+			want:    `"chunk1chunk2chunk3"`,
 		},
 	}
 

--- a/internal/stackitprovider/records.go
+++ b/internal/stackitprovider/records.go
@@ -8,6 +8,8 @@ import (
 	"sigs.k8s.io/external-dns/provider"
 )
 
+const txtRecord = "TXT"
+
 // Records returns resource records.
 func (d *StackitDNSProvider) Records(ctx context.Context) ([]*endpoint.Endpoint, error) {
 	zones, err := d.zoneFetcherClient.zones(ctx)
@@ -115,7 +117,7 @@ func endpointsFromRecords(name, recordType string, ttl endpoint.TTL, records []s
 		rec := &records[i]
 
 		content := rec.Content
-		if recordType == "TXT" {
+		if recordType == txtRecord {
 			content = unformatTXTContent(content)
 		}
 

--- a/internal/stackitprovider/records.go
+++ b/internal/stackitprovider/records.go
@@ -114,7 +114,12 @@ func endpointsFromRecords(name, recordType string, ttl endpoint.TTL, records []s
 	for i := range records {
 		rec := &records[i]
 
-		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, recordType, ttl, rec.Content))
+		content := rec.Content
+		if recordType == "TXT" {
+			content = unformatTXTContent(content)
+		}
+
+		endpoints = append(endpoints, endpoint.NewEndpointWithTTL(name, recordType, ttl, content))
 	}
 
 	return endpoints


### PR DESCRIPTION
This pull request updates the handling of DNS TXT records to ensure proper formatting and parsing according to DNS standards. The main improvements are the introduction of helper functions to split long TXT records into 255-character chunks (as required by DNS), and to reassemble them when reading records. These changes help prevent issues with TXT records that exceed the DNS length limit.